### PR TITLE
Fix VQ Huffman decode for Champions of Norrath level textures

### DIFF
--- a/src/main/java/net/ijbrown/jbgda/loaders/LevelTexDecode.java
+++ b/src/main/java/net/ijbrown/jbgda/loaders/LevelTexDecode.java
@@ -209,7 +209,7 @@ public class LevelTexDecode
 
             table.values.add(code1 >>> 2);
             int shiftVal = (32 - numBits) & 0x1f;
-            table.subtracts[32 - numBits] = code1 >>> shiftVal;
+            table.subtracts[32 - numBits] = (code1 >>> shiftVal) - code2;
 
             Logger.debug("    numBits = {}, shiftVal = {}, code1 = {}, code2 = {}", numBits, shiftVal, code1, code2);
             Logger.debug("        tableVal = {}, subtracts = {}", table.values.getLast(), table.subtracts[32 - numBits]);


### PR DESCRIPTION
The `decodeHuffman` method builds the `subtracts` table by shifting `code1` but never subtracts `code2`. The engine's `processHuffman` does both (`*v4 = *v2 >> v5` then `*v4-- -= v8`).\n\nThis one-line fix changes:\n`java\ntable.subtracts[32 - numBits] = code1 >>> shiftVal;\n`\nto:\n`java\ntable.subtracts[32 - numBits] = (code1 >>> shiftVal) - code2;\n`\n\nWithout the subtraction, most Huffman table entries have wrong base offsets, causing nearly every VQ codebook lookup to resolve to the wrong entry. This produces the noisy output seen when decoding Champions of Norrath level textures.\n\nVerified by porting `extractVQ` to Python with this fix and decoding textures from KELETHIN.TEX, GNOMEHUB.TEX, and RUININT3.TEX — all produce clean results.